### PR TITLE
help find Anaconda3 folder in Windows

### DIFF
--- a/Lectures/pip-and-conda-install.md
+++ b/Lectures/pip-and-conda-install.md
@@ -79,7 +79,10 @@ is done by modifying the `PATH` environment variable.
 
 To fix this error on windows, find the install location of anaconda. There
 should be an `Anaconda3` folder in your user directory. Note the path down for
-this. Then create a `.bashrc` file in your home directory (`vim ~/.bashrc`) and
+this.
+* If you have any trouble finding the `Anaconda3` folder, open the "Anaconda Prompt" (you can find it from the Windows 10 search bar), and type `conda info`. The desired path should be listed under "base environment".
+
+Then create a `.bashrc` file in your home directory (`vim ~/.bashrc`) and
 put the following line in:
 ```
 export PATH=/c/[YOUR PATH TO Anaconda3 folder here]/Scripts:$PATH


### PR DESCRIPTION
While installing Anaconda3, if you (foolishly) selected to install for all users on the machine (me) you might not find the Anaconda3 folder in your user directory, instead you would probably find it in C:\ProgramData. To account for this, I added a few lines to the pip-and-conda-install.md document that should work as a general way for a Windows installer of Anaconda to find its elusive path.