### PR TITLE
Add note to import pytest when using pytest decorators

### DIFF
--- a/Lectures/UnitTestingCI.md
+++ b/Lectures/UnitTestingCI.md
@@ -107,3 +107,4 @@ The list of tuples is the list of input & expected output arguments to call the 
 
 You can see a live example of this working code and play around with it yourself [here](unit_testing/)
 
+__Note__:  By adding the decorator described above, we now have a specific reference to pytest in our code file.  For the decorator to be recognized, we must import pytest in the module (```import pytest```) for the decorator to work. 


### PR DESCRIPTION
Suyash, I added a note to the end of your Unit Testing section about importing pytest into the module when using the pytest decorator.  It was an issue for a number of folks today, so I think it is best to capture.  Let me know if you would suggest something different.  Thanks, Dave