### PR TITLE
fix axios vulnerabilities (bump to >=1.15.2)

### DIFF
--- a/Lectures/react/counter-example/my-app/package.json
+++ b/Lectures/react/counter-example/my-app/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "axios": ">=1.15.0",
+    "axios": ">=1.15.2",
     "material-ui": "^1.0.0-beta.38",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",


### PR DESCRIPTION
## Summary
- Bumps axios in `Lectures/react/counter-example/my-app/package.json` from `>=1.15.0` to `>=1.15.2`
- Closes all 8 currently-open Dependabot alerts on this manifest

## Alerts closed
| # | Severity | GHSA / CVE | Summary |
|---|---|---|---|
| 6 | high | GHSA-7m4w-8c6f-mh78 | Header injection via prototype pollution |
| 7 | medium | GHSA-5pq6-fjcw-ph2v | HTTP adapter streamed responses bypass maxContentLength |
| 8 | high | GHSA-jr5f-v2jv-69x6 | Prototype pollution gadgets (response tampering / exfil / hijacking) |
| 9 | low | GHSA-c4r9-r8fh-9vj2 | Null byte injection via reverse-encoding in AxiosURLSearchParams |
| 10 | medium | GHSA-4wf5-vphf-c2xc | Invisible JSON response tampering via prototype pollution in parseReviver |
| 11 | medium | GHSA-9j3m-vvrx-jh5w | no_proxy bypass via IP alias allows SSRF |
| 12 | medium | GHSA-4hjh-wcwx-q44q | CRLF injection in multipart/form-data via unsanitized blob.type |
| 13 | medium | GHSA-5c9x-8gcm-mpgx / CVE-2026-42034 | HTTP adapter streamed uploads bypass maxBodyLength when maxRedirects: 0 |

All 8 alerts share the same first-patched version (`1.15.2`), so one bump resolves them all.

## Test plan
- [ ] Confirm Dependabot closes alerts #6–#13 after merge
- [ ] No package-lock.json is committed in this directory, so no lockfile churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)